### PR TITLE
Docker build/Python 3 Ubuntu testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM sd2e/python3:ubuntu17
+
+RUN apt-get update
+RUN apt-get -y install libxslt1-dev
+
+RUN git clone https://github.com/SD2E/xplan_to_sbol
+
+COPY xplan_to_sbol /xplan_to_sbol
+
+# custom wheel for python 3.6
+RUN pip3 install https://github.com/tcmitchell/pySBOL/blob/ubuntu/Ubuntu_16.04_64_3/dist/pySBOL-2.3.0.post11-cp36-none-any.whl?raw=true
+
+# returns a non-zero exit code looking for a windows dependency
+RUN cd /xplan_to_sbol && python3 setup.py install || true
+
+RUN cd /xplan_to_sbol && python3 -m tests.SBOLTestSuite

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+CONTAINER_IMAGE="sd2e/xplan_to_sbol:1.0"
+
+docker build -t ${CONTAINER_IMAGE} .


### PR DESCRIPTION
@tramyn @nroehner can you review the following output. How does this look?
```
Sending build context to Docker daemon  5.532MB
Step 1/8 : FROM sd2e/python3:ubuntu17
 ---> a5d4322ef2c3
Step 2/8 : RUN apt-get update
 ---> Using cache
 ---> aedd64e79c92
Step 3/8 : RUN apt-get -y install libxslt1-dev
 ---> Running in 884754e32f79
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  icu-devtools libicu-dev libxml2-dev libxslt1.1
Suggested packages:
  icu-doc pkg-config
The following NEW packages will be installed:
  icu-devtools libicu-dev libxml2-dev libxslt1-dev libxslt1.1
0 upgraded, 5 newly installed, 0 to remove and 0 not upgraded.
Need to get 18.0 MB of archives.
After this operation, 101 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu artful-updates/main amd64 icu-devtools amd64 57.1-6ubuntu0.2 [169 kB]
Get:2 http://archive.ubuntu.com/ubuntu artful-updates/main amd64 libicu-dev amd64 57.1-6ubuntu0.2 [16.6 MB]
Get:3 http://archive.ubuntu.com/ubuntu artful-updates/main amd64 libxml2-dev amd64 2.9.4+dfsg1-4ubuntu1.2 [757 kB]
Get:4 http://archive.ubuntu.com/ubuntu artful/main amd64 libxslt1.1 amd64 1.1.29-2.1ubuntu1 [149 kB]
Get:5 http://archive.ubuntu.com/ubuntu artful/main amd64 libxslt1-dev amd64 1.1.29-2.1ubuntu1 [406 kB]
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin: 
Fetched 18.0 MB in 7s (2519 kB/s)
Selecting previously unselected package icu-devtools.
(Reading database ... 19850 files and directories currently installed.)
Preparing to unpack .../icu-devtools_57.1-6ubuntu0.2_amd64.deb ...
Unpacking icu-devtools (57.1-6ubuntu0.2) ...
Selecting previously unselected package libicu-dev.
Preparing to unpack .../libicu-dev_57.1-6ubuntu0.2_amd64.deb ...
Unpacking libicu-dev (57.1-6ubuntu0.2) ...
Selecting previously unselected package libxml2-dev:amd64.
Preparing to unpack .../libxml2-dev_2.9.4+dfsg1-4ubuntu1.2_amd64.deb ...
Unpacking libxml2-dev:amd64 (2.9.4+dfsg1-4ubuntu1.2) ...
Selecting previously unselected package libxslt1.1:amd64.
Preparing to unpack .../libxslt1.1_1.1.29-2.1ubuntu1_amd64.deb ...
Unpacking libxslt1.1:amd64 (1.1.29-2.1ubuntu1) ...
Selecting previously unselected package libxslt1-dev:amd64.
Preparing to unpack .../libxslt1-dev_1.1.29-2.1ubuntu1_amd64.deb ...
Unpacking libxslt1-dev:amd64 (1.1.29-2.1ubuntu1) ...
Setting up libxslt1.1:amd64 (1.1.29-2.1ubuntu1) ...
Processing triggers for libc-bin (2.26-0ubuntu2.1) ...
Setting up icu-devtools (57.1-6ubuntu0.2) ...
Setting up libicu-dev (57.1-6ubuntu0.2) ...
Setting up libxml2-dev:amd64 (2.9.4+dfsg1-4ubuntu1.2) ...
Setting up libxslt1-dev:amd64 (1.1.29-2.1ubuntu1) ...
 ---> e38aa9175fce
Step 4/8 : RUN git clone https://github.com/SD2E/xplan_to_sbol
 ---> Running in d5cc91962094
Cloning into 'xplan_to_sbol'...
 ---> 0d62cd9a5732
Step 5/8 : COPY xplan_to_sbol /xplan_to_sbol
 ---> a4ac6515bff6
Step 6/8 : RUN pip3 install https://github.com/tcmitchell/pySBOL/blob/ubuntu/Ubuntu_16.04_64_3/dist/pySBOL-2.3.0.post11-cp36-none-any.whl?raw=true
 ---> Running in e9e9de483e48
Collecting pySBOL==2.3.0.post11 from https://github.com/tcmitchell/pySBOL/blob/ubuntu/Ubuntu_16.04_64_3/dist/pySBOL-2.3.0.post11-cp36-none-any.whl?raw=true
  Downloading https://github.com/tcmitchell/pySBOL/blob/ubuntu/Ubuntu_16.04_64_3/dist/pySBOL-2.3.0.post11-cp36-none-any.whl?raw=true (6.9MB)
Installing collected packages: pySBOL
Successfully installed pySBOL-2.3.0.post11
 ---> 135b96b09287
Step 7/8 : RUN cd /xplan_to_sbol && python3 setup.py install || true
 ---> Running in 46c991fb5d73
running install
running bdist_egg
running egg_info
creating xplan_to_sbol.egg-info
writing xplan_to_sbol.egg-info/PKG-INFO
writing dependency_links to xplan_to_sbol.egg-info/dependency_links.txt
writing entry points to xplan_to_sbol.egg-info/entry_points.txt
writing requirements to xplan_to_sbol.egg-info/requires.txt
writing top-level names to xplan_to_sbol.egg-info/top_level.txt
writing manifest file 'xplan_to_sbol.egg-info/SOURCES.txt'
reading manifest file 'xplan_to_sbol.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'xplan_to_sbol.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
creating build
creating build/lib
creating build/lib/xplan_to_sbol
copying xplan_to_sbol/__main__.py -> build/lib/xplan_to_sbol
copying xplan_to_sbol/ConversionUtil.py -> build/lib/xplan_to_sbol
copying xplan_to_sbol/__init__.py -> build/lib/xplan_to_sbol
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/xplan_to_sbol
copying build/lib/xplan_to_sbol/__main__.py -> build/bdist.linux-x86_64/egg/xplan_to_sbol
copying build/lib/xplan_to_sbol/ConversionUtil.py -> build/bdist.linux-x86_64/egg/xplan_to_sbol
copying build/lib/xplan_to_sbol/__init__.py -> build/bdist.linux-x86_64/egg/xplan_to_sbol
byte-compiling build/bdist.linux-x86_64/egg/xplan_to_sbol/__main__.py to __main__.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/xplan_to_sbol/ConversionUtil.py to ConversionUtil.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/xplan_to_sbol/__init__.py to __init__.cpython-36.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying xplan_to_sbol.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying xplan_to_sbol.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying xplan_to_sbol.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying xplan_to_sbol.egg-info/entry_points.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying xplan_to_sbol.egg-info/not-zip-safe -> build/bdist.linux-x86_64/egg/EGG-INFO
copying xplan_to_sbol.egg-info/requires.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying xplan_to_sbol.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
creating dist
creating 'dist/xplan_to_sbol-0.1-py3.6.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing xplan_to_sbol-0.1-py3.6.egg
creating /usr/local/lib/python3.6/dist-packages/xplan_to_sbol-0.1-py3.6.egg
Extracting xplan_to_sbol-0.1-py3.6.egg to /usr/local/lib/python3.6/dist-packages
Adding xplan-to-sbol 0.1 to easy-install.pth file
Installing xplan_to_sbol script to /usr/local/bin

Installed /usr/local/lib/python3.6/dist-packages/xplan_to_sbol-0.1-py3.6.egg
Processing dependencies for xplan-to-sbol==0.1
Searching for pySBOLx
Doing git clone from https://git@github.com/nroehner/pySBOLx.git to /tmp/easy_install-nrysemh8/pySBOLx.git
Best match: pySBOLx [unknown version]
Processing pySBOLx.git
Writing /tmp/easy_install-nrysemh8/pySBOLx.git/setup.cfg
Running setup.py -q bdist_egg --dist-dir /tmp/easy_install-nrysemh8/pySBOLx.git/egg-dist-tmp-5f6szbwo
creating /usr/local/lib/python3.6/dist-packages/pySBOLx-0.1-py3.6.egg
Extracting pySBOLx-0.1-py3.6.egg to /usr/local/lib/python3.6/dist-packages
Adding pySBOLx 0.1 to easy-install.pth file

Installed /usr/local/lib/python3.6/dist-packages/pySBOLx-0.1-py3.6.egg
Searching for sbol
Doing git clone from https://git@github.com/nroehner/pySBOL_Win_64_3.git to /tmp/easy_install-cbp1yyoo/pySBOL_Win_64_3.git
Best match: sbol [unknown version]
Processing pySBOL_Win_64_3.git
Writing /tmp/easy_install-cbp1yyoo/pySBOL_Win_64_3.git/setup.cfg
Running setup.py -q bdist_egg --dist-dir /tmp/easy_install-cbp1yyoo/pySBOL_Win_64_3.git/egg-dist-tmp-k6ufawi0
Installing libSBOL binaries for Linux 64-bit 3.6.3 (default, Oct  3 2017, 21:45:48) 
[GCC 7.2.0]
Linux_64_3
package init file 'sbol/test/__init__.py' not found (or not a regular file)
creating /usr/local/lib/python3.6/dist-packages/sbol-0.1-py3.6.egg
Extracting sbol-0.1-py3.6.egg to /usr/local/lib/python3.6/dist-packages
Adding sbol 0.1 to easy-install.pth file

Installed /usr/local/lib/python3.6/dist-packages/sbol-0.1-py3.6.egg
Searching for rdflib
Reading https://pypi.python.org/simple/rdflib/
Downloading https://pypi.python.org/packages/3c/fe/630bacb652680f6d481b9febbb3e2c3869194a1a5fc3401a4a41195a2f8f/rdflib-4.2.2-py3-none-any.whl#md5=380422af59a6f0e5cc62879f68de3397
Best match: rdflib 4.2.2
Processing rdflib-4.2.2-py3-none-any.whl
Installing rdflib-4.2.2-py3-none-any.whl to /usr/local/lib/python3.6/dist-packages
writing requirements to /usr/local/lib/python3.6/dist-packages/rdflib-4.2.2-py3.6.egg/EGG-INFO/requires.txt
Adding rdflib 4.2.2 to easy-install.pth file
Installing csv2rdf script to /usr/local/bin
Installing rdf2dot script to /usr/local/bin
Installing rdfgraphisomorphism script to /usr/local/bin
Installing rdfpipe script to /usr/local/bin
Installing rdfs2dot script to /usr/local/bin

Installed /usr/local/lib/python3.6/dist-packages/rdflib-4.2.2-py3.6.egg
Searching for pyparsing
Reading https://pypi.python.org/simple/pyparsing/
Downloading https://pypi.python.org/packages/6a/8a/718fd7d3458f9fab8e67186b00abdd345b639976bc7fb3ae722e1b026a50/pyparsing-2.2.0-py2.py3-none-any.whl#md5=7247e7896688eff4bc8c7fc5d0cdd2b0
Best match: pyparsing 2.2.0
Processing pyparsing-2.2.0-py2.py3-none-any.whl
Installing pyparsing-2.2.0-py2.py3-none-any.whl to /usr/local/lib/python3.6/dist-packages
Adding pyparsing 2.2.0 to easy-install.pth file

Installed /usr/local/lib/python3.6/dist-packages/pyparsing-2.2.0-py3.6.egg
Searching for isodate
Reading https://pypi.python.org/simple/isodate/
Downloading https://pypi.python.org/packages/9b/9f/b36f7774ff5ea8e428fdcfc4bb332c39ee5b9362ddd3d40d9516a55221b2/isodate-0.6.0-py2.py3-none-any.whl#md5=d993beffb0b78627721d9ef1dda4df87
Best match: isodate 0.6.0
Processing isodate-0.6.0-py2.py3-none-any.whl
Installing isodate-0.6.0-py2.py3-none-any.whl to /usr/local/lib/python3.6/dist-packages
writing requirements to /usr/local/lib/python3.6/dist-packages/isodate-0.6.0-py3.6.egg/EGG-INFO/requires.txt
Adding isodate 0.6.0 to easy-install.pth file

Installed /usr/local/lib/python3.6/dist-packages/isodate-0.6.0-py3.6.egg
Searching for six==1.11.0
Best match: six 1.11.0
Adding six 1.11.0 to easy-install.pth file

Using /usr/local/lib/python3.6/dist-packages
Finished processing dependencies for xplan-to-sbol==0.1
 ---> db3c56a357a7
Step 8/8 : RUN cd /xplan_to_sbol && python3 -m tests.SBOLTestSuite
 ---> Running in ca95f153edd2
...
----------------------------------------------------------------------
Ran 3 tests in 0.008s

OK
.Values  in Document 1::identity not equal to values in Document 2::identity
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/dilute_NEB_10_beta_pAN1201_1_to_NEB_10_beta_pAN1201_2/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/dilute_NEB_10_beta_pAN1201_2_to_NEB_10_beta_pAN1201_3/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/dilute_NEB_10_beta_pAN1201_3_to_A01_1/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/dilute_NEB_10_beta_pAN1717_1_to_NEB_10_beta_pAN1717_2/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/dilute_NEB_10_beta_pAN1717_2_to_NEB_10_beta_pAN1717_3/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/dilute_NEB_10_beta_pAN3928_pAN4036_1_to_NEB_10_beta_pAN3928_pAN4036_2/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/dilute_NEB_10_beta_pAN3928_pAN4036_2_to_NEB_10_beta_pAN3928_pAN4036_3/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A01_to_A01_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A02_to_A02_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A03_to_A03_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A04_to_A04_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A05_to_A05_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A06_to_A06_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A07_to_A07_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A08_to_A08_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_A09_to_A09_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B01_to_B01_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B02_to_B02_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B03_to_B03_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B04_to_B04_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B05_to_B05_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B06_to_B06_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B07_to_B07_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B08_to_B08_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_B09_to_B09_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C01_to_C01_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C02_to_C02_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C03_to_C03_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C04_to_C04_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C05_to_C05_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C06_to_C06_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C07_to_C07_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C08_to_C08_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_C09_to_C09_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D01_to_D01_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D02_to_D02_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D03_to_D03_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D04_to_D04_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D05_to_D05_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D06_to_D06_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D07_to_D07_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D08_to_D08_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_D09_to_D09_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E01_to_E01_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E02_to_E02_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E03_to_E03_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E04_to_E04_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E05_to_E05_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E06_to_E06_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E07_to_E07_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E08_to_E08_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_E09_to_E09_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F01_to_F01_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F02_to_F02_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F03_to_F03_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F04_to_F04_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F05_to_F05_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F06_to_F06_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F07_to_F07_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F08_to_F08_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_F09_to_F09_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G01_to_G01_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G02_to_G02_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G03_to_G03_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G04_to_G04_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G05_to_G05_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G06_to_G06_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G07_to_G07_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G08_to_G08_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_G09_to_G09_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H01_to_H01_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H02_to_H02_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H03_to_H03_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H04_to_H04_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H05_to_H05_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H06_to_H06_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H07_to_H07_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H08_to_H08_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_H09_to_H09_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/flowCytometry_beadcontrol_to_beadcontrol_flowCytometry_11/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/incubate_A01_1/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/incubate_NEB_10_beta_pAN1201_1/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/incubate_NEB_10_beta_pAN1201_2/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/incubate_NEB_10_beta_pAN1717_1/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/incubate_NEB_10_beta_pAN1717_2/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/incubate_NEB_10_beta_pAN3928_pAN4036_1/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/incubate_NEB_10_beta_pAN3928_pAN4036_2/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/pick_NEB_10_beta_pAN1201_to_NEB_10_beta_pAN1201_1/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/pick_NEB_10_beta_pAN1717_to_NEB_10_beta_pAN1717_1/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/pick_NEB_10_beta_pAN3928_pAN4036_to_NEB_10_beta_pAN3928_pAN4036_1/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/prepare_plasmids_pAN1201_streak_to_pAN1201/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/prepare_plasmids_pAN1717_streak_to_pAN1717/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/prepare_plasmids_pAN3928_streak_to_pAN3928/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/prepare_plasmids_pAN4036_streak_to_pAN4036/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/rnaSeq_A01_1_rnaSeq_10/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_A01/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_A02/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_A03/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_B01/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_B02/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_B03/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_C01/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_C02/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_C03/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_D01/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_D02/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_D03/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_E01/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_E02/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_E03/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_F01/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_F02/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_F03/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_G01/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_G02/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_G03/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_H01/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_H02/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1201_3_to_H03/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_A07/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_A08/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_A09/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_B07/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_B08/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_B09/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_C07/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_C08/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_C09/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_D07/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_D08/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_D09/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_E07/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_E08/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_E09/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_F07/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_F08/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_F09/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_G07/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_G08/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_G09/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_H07/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_H08/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN1717_3_to_H09/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_A04/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_A05/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_A06/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_B04/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_B05/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_B06/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_C04/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_C05/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_C06/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_D04/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_D05/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_D06/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_E04/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_E05/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_E06/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_F04/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_F05/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_F06/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_G04/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_G05/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_G06/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_H04/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_H05/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transfer_NEB_10_beta_pAN3928_pAN4036_3_to_H06/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transform_pAN1201_NEB_10_beta_to_NEB_10_beta_pAN1201/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transform_pAN1717_NEB_10_beta_to_NEB_10_beta_pAN1717/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument
Child object http://hub.sd2e.org/user/sd2e/transcriptic_rule_30_q0_1_09242017/transform_pAN3928_pAN4036_NEB_10_beta_to_NEB_10_beta_pAN3928_pAN4036/1.0.0 not in Activity property of rule30-Q0-v2_conversionDocument

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
F.......EF..............EF.............EF.F.............EF............F.EF................EF..........
======================================================================
ERROR: test_Experiment_displayId (tests.Test_R30_1.TestR30_1)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_1.py", line 152, in test_Experiment_displayId
    actual_d_id = experiment_obj.getAnnotation(SBOLNamespace.DISPLAYID_NS)
AttributeError: 'NoneType' object has no attribute 'getAnnotation'

======================================================================
ERROR: test_Experiment_displayId (tests.Test_R30_2.TestR30_2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_2.py", line 152, in test_Experiment_displayId
    actual_d_id = experiment_obj.getAnnotation(SBOLNamespace.DISPLAYID_NS)
AttributeError: 'NoneType' object has no attribute 'getAnnotation'

======================================================================
ERROR: test_Experiment_displayId (tests.Test_R30_3.TestR30_3)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_3.py", line 153, in test_Experiment_displayId
    actual_d_id = experiment_obj.getAnnotation(SBOLNamespace.DISPLAYID_NS)
AttributeError: 'NoneType' object has no attribute 'getAnnotation'

======================================================================
ERROR: test_Experiment_displayId (tests.Test_R30_4.TestR30_4)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_4.py", line 142, in test_Experiment_displayId
    actual_d_id = experiment_obj.getAnnotation(SBOLNamespace.DISPLAYID_NS)
AttributeError: 'NoneType' object has no attribute 'getAnnotation'

======================================================================
ERROR: test_Experiment_displayId (tests.Test_R30_5.TestR30_5)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_5.py", line 166, in test_Experiment_displayId
    actual_d_id = experiment_obj.getAnnotation(SBOLNamespace.DISPLAYID_NS)
AttributeError: 'NoneType' object has no attribute 'getAnnotation'

======================================================================
ERROR: test_Experiment_displayId (tests.Test_R30_6.TestR30_6)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_6.py", line 166, in test_Experiment_displayId
    actual_d_id = experiment_obj.getAnnotation(SBOLNamespace.DISPLAYID_NS)
AttributeError: 'NoneType' object has no attribute 'getAnnotation'

======================================================================
FAIL: test_SBOLFiles_diff (tests.Test_Rule30.TestRule30)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_Rule30.py", line 61, in test_SBOLFiles_diff
    self.assertTrue(sbolDiff_res == 1)
AssertionError: False is not true

======================================================================
FAIL: test_Experiment_ids (tests.Test_R30_1.TestR30_1)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_1.py", line 121, in test_Experiment_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//rule_30_transcriptic_rule_30_q0_1_09242017/1'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//transcriptic_rule_30_q0_1_09242017/1'

======================================================================
FAIL: test_Experiment_ids (tests.Test_R30_2.TestR30_2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_2.py", line 121, in test_Experiment_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//rule_30_transcriptic_rule_30_q0_1_09242017/1'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//transcriptic_rule_30_q0_1_09242017/1'

======================================================================
FAIL: test_Experiment_ids (tests.Test_R30_3.TestR30_3)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_3.py", line 122, in test_Experiment_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//rule_30_transcriptic_rule_30_q0_1_09242017/1'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//transcriptic_rule_30_q0_1_09242017/1'

======================================================================
FAIL: test_Implementation_ids (tests.Test_R30_3.TestR30_3)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_3.py", line 115, in test_Implementation_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//NEB_10_beta_pAN1201_1/1.0.0'
'https://hub.sd2e.org/user/sd2e//NEB_10_beta_pAN1717_1/1.0.0'
'https://hub.sd2e.org/user/sd2e//NEB_10_beta_pAN3928_pAN4036_1/1.0.0'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//NEB_10_beta_pAN1717_1/1'
'https://hub.sd2e.org/user/sd2e//NEB_10_beta_pAN3928_pAN4036_1/1'
'https://hub.sd2e.org/user/sd2e//NEB_10_beta_pAN1201_1/1'

======================================================================
FAIL: test_Experiment_ids (tests.Test_R30_4.TestR30_4)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_4.py", line 111, in test_Experiment_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//rule_30_transcriptic_rule_30_q0_1_09242017/1'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//transcriptic_rule_30_q0_1_09242017/1'

======================================================================
FAIL: test_Attachment_ids (tests.Test_R30_5.TestR30_5)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_5.py", line 114, in test_Attachment_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//transcriptic_rule_30_q0_1_09242017_instrument_output_SD30_09242017_SD30_09242017_Rule30Plate_A12_fcs/1'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//instrument_output/1'

======================================================================
FAIL: test_Experiment_ids (tests.Test_R30_5.TestR30_5)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_5.py", line 128, in test_Experiment_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//rule_30_transcriptic_rule_30_q0_1_09242017/1'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//transcriptic_rule_30_q0_1_09242017/1'

======================================================================
FAIL: test_Experiment_ids (tests.Test_R30_6.TestR30_6)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_R30_6.py", line 128, in test_Experiment_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//rule_30_transcriptic_rule_30_q0_1_09242017/1'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//transcriptic_rule_30_q0_1_09242017/1'
Namespaces do not match
Values  in Document 1::identity not equal to values in Document 2::identity
Child object https://hub.sd2e.org/user/sd2e//dilute_biofab_sample_yeast_gates_q0_1_3_A01_1_1/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//flowCytometry_biofab_sample_yeast_gates_q0_1_4_A01_1_1_flowCytometry_11/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//incubate_biofab_sample_yeast_gates_q0_1_1_A01/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//incubate_biofab_sample_yeast_gates_q0_1_3_A01_1_1/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//mix/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//mix_biofab_sample_yeast_gates_q0_1_2_A01_1/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//mix_biofab_sample_yeast_gates_q0_1_4_A01_1_1/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//pick_biofab_sample_yeast_gates_q0_1_2_A01_1/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//pick_biofab_sample_yeast_gates_q0_1_2_A01_2/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//pick_biofab_sample_yeast_gates_q0_1_2_A01_3/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//pick_biofab_sample_yeast_gates_q0_1_2_A01_4/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//pick_biofab_sample_yeast_gates_q0_1_2_A01_5/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//pick_biofab_sample_yeast_gates_q0_1_2_A01_6/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//spectrophotometry_biofab_sample_yeast_gates_q0_1_2_A01_1_spectrophotometry_4/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//spectrophotometry_biofab_sample_yeast_gates_q0_1_4_A01_1_1_spectrophotometry_9/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//streak_biofab_sample_yeast_gates_q0_1_1_STOCK01_to_biofab_sample_yeast_gates_q0_1_1_A01/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument
Child object https://hub.sd2e.org/user/sd2e//transfer_biofab_sample_yeast_gates_q0_1_4_A01_1_1/1.0.0 not in Activity property of yeastGates-Q0-v2_goldenDocument

----------------------------------------------------------------------
Ran 102 tests in 33.261s

FAILED (failures=9, errors=6)
F.........................F................
======================================================================
FAIL: test_SBOLFiles_diff (tests.Test_yeastGates.TestYeastGates)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_yeastGates.py", line 62, in test_SBOLFiles_diff
    self.assertTrue(sbolDiff_res == 1)
AssertionError: False is not true

======================================================================
FAIL: test_Implementation_ids (tests.Test_YG_2.TestYG_2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/xplan_to_sbol/tests/Test_YG_2.py", line 115, in test_Implementation_ids
    self.assertEqual(expected_ids, actual_ids)
AssertionError: Items in the first set but not the second:
'https://hub.sd2e.org/user/sd2e//biofab_sample_yeast_gates_q0_1_1_A01/1.0.0'
Items in the second set but not the first:
'https://hub.sd2e.org/user/sd2e//biofab_sample_yeast_gates_q0_1_1_A01/1'

----------------------------------------------------------------------
Ran 43 tests in 14.538s

FAILED (failures=2)
Running TestXplanDataParser
Running testPySBOLx
Running TestRule30
Running TestR30_1
Running TestR30_2
Running TestR30_3
Running TestR30_4
Running TestR30_5
Running TestR30_6
Running TestYeastGates
Running TestYG_1
Running TestYG_2
<?xml version="1.0" encoding="utf-8"?>
<rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/"
   xmlns:prov="http://www.w3.org/ns/prov#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:sbol="http://sbols.org/v2#"
   xmlns:sd2="http://sd2e.org#"
   xmlns:sys-bio="http://sys-bio.org#">
  <sd2:Implementation rdf:about="https://hub.sd2e.org/user/sd2e//biofab_sample_yeast_gates_q0_1_1_A01/1">
    <dcterms:title>biofab_sample_yeast_gates_q0_1_1_A01</dcterms:title>
    <sbol:displayId>biofab_sample_yeast_gates_q0_1_1_A01</sbol:displayId>
    <sbol:persistentIdentity rdf:resource="https://hub.sd2e.org/user/sd2e//biofab_sample_yeast_gates_q0_1_1_A01"/>
    <sbol:version>1</sbol:version>
  </sd2:Implementation>
  <sd2:Experiment rdf:about="https://hub.sd2e.org/user/sd2e//df82e79b_e18c_457e_8c5c_ed605acc94cd/1">
    <dcterms:title>Yeast Gates Q0 Plan</dcterms:title>
    <sbol:displayId>df82e79b_e18c_457e_8c5c_ed605acc94cd</sbol:displayId>
    <sbol:persistentIdentity rdf:resource="https://hub.sd2e.org/user/sd2e//df82e79b_e18c_457e_8c5c_ed605acc94cd"/>
    <sbol:version>1</sbol:version>
  </sd2:Experiment>
  <prov:Activity rdf:about="https://hub.sd2e.org/user/sd2e//incubate_biofab_sample_yeast_gates_q0_1_1_A01/1.0.0">
    <dcterms:description>Incubate (30C, 2 days), YPAD-plate_1</dcterms:description>
    <dcterms:title>Incubate Operator</dcterms:title>
    <sbol:displayId>incubate_biofab_sample_yeast_gates_q0_1_1_A01</sbol:displayId>
    <sbol:persistentIdentity rdf:resource="https://hub.sd2e.org/user/sd2e//incubate_biofab_sample_yeast_gates_q0_1_1_A01"/>
    <sbol:version>1</sbol:version>
    <sd2:operatorType rdf:resource="http://sd2e.org#incubate"/>
    <prov:qualifiedUsage>
      <prov:Usage rdf:about="https://hub.sd2e.org/user/sd2e//incubate_biofab_sample_yeast_gates_q0_1_1_A01/biofab_sample_yeast_gates_q0_1_1_A01/1">
        <sbol:displayId>biofab_sample_yeast_gates_q0_1_1_A01</sbol:displayId>
        <sbol:persistentIdentity rdf:resource="https://hub.sd2e.org/user/sd2e//incubate_biofab_sample_yeast_gates_q0_1_1_A01/biofab_sample_yeast_gates_q0_1_1_A01"/>
        <sbol:version>1</sbol:version>
        <prov:entity rdf:resource="https://hub.sd2e.org/user/sd2e//biofab_sample_yeast_gates_q0_1_1_A01/1"/>
        <prov:hadRole rdf:resource="http://sbols.org/v2#build"/>
      </prov:Usage>
    </prov:qualifiedUsage>
  </prov:Activity>
</rdf:RDF>

Running TestYG_3
Attachment....................0
Collection....................0
CombinatorialDerivation.......0
ComponentDefinition...........0
Implementation................0
Model.........................0
ModuleDefinition..............0
Sequence......................0
Analysis......................0
Build.........................0
Design........................0
SampleRoster..................0
Test..........................0
Activity......................1
Agent.........................0
Plan..........................0
Annotation Objects............4
---
Total.........................5

 ---> e27a0276220f
Removing intermediate container 46c991fb5d73
Removing intermediate container ca95f153edd2
Removing intermediate container 884754e32f79
Removing intermediate container d5cc91962094
Removing intermediate container e9e9de483e48
Successfully built e27a0276220f
Successfully tagged sd2e/xplan_to_sbol:1.0
```