### PR TITLE
Automatically link intent as an attachment, add bead and wild type (negative controls) if found.

### DIFF
--- a/example/xplan/biofab_yg_UWBF_NOR_intent_control_test.json
+++ b/example/xplan/biofab_yg_UWBF_NOR_intent_control_test.json
@@ -1,0 +1,7367 @@
+{
+    "cost": 558.0,
+    "experiment_id": "intent_control_test",
+    "experiment_lab": "biofab",
+    "experiment_set": "https://hub.sd2e.org/user/sd2e/experiment/yeast_gates_q0/1",
+    "id": "https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1",
+    "intent": {
+        "controls": [
+            {
+                "design_name": "UWBIOFAB_Scerevisiae_MATa/alpha"
+            }
+        ],
+        "diagnostic-variables": [
+            {
+                "name": "media_name",
+                "statistical-datatype": "nominal"
+            },
+            {
+                "name": "target_od",
+                "statistical-datatype": "nominal"
+            }
+        ],
+        "experimental-variables": [
+            {
+                "name": "design_name",
+                "statistical-datatype": "nominal"
+            }
+        ],
+        "outcome-variables": [
+            {
+                "name": "GFP",
+                "statistical-datatype": "counts"
+            }
+        ],
+        "search": {
+            "sql": [
+                "SELECT                                                   ",
+                "   design_name                                           ",
+                "   AVG(misbehaving_row) AS probability_surprising        ",
+                "   FROM circuit_analysis_results                         ",
+                "      GROUP BY                                           ",
+                "           design_name                                   ",
+                "           ORDER BY probability_surprising DESC          "
+            ]
+        },
+        "truth-table": {
+            "input": [
+                [
+                    0,
+                    0
+                ],
+                [
+                    0,
+                    1
+                ],
+                [
+                    1,
+                    0
+                ],
+                [
+                    1,
+                    1
+                ]
+            ],
+            "input-variable-order": [
+                "design_name"
+            ],
+            "mappings": {
+                "design_name": {
+                    "UWBF_NOR_00": [
+                        0,
+                        0
+                    ],
+                    "UWBF_NOR_01": [
+                        0,
+                        1
+                    ],
+                    "UWBF_NOR_10": [
+                        1,
+                        0
+                    ],
+                    "UWBF_NOR_11": [
+                        1,
+                        1
+                    ]
+                }
+            },
+            "output": [
+                1,
+                0,
+                0,
+                0
+            ],
+            "output-variable": "GFP"
+        }
+    },
+    "name": "yeast-gates_q0_47_biofab_c37975fd-240d-4011-8e45-70a0d99a95d4_Plan",
+    "steps": [
+        {
+            "id": 0,
+            "name": "Step 0",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 0,
+                "name": "Provision Operator",
+                "transformations": [
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s3/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s4/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s5/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s6/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s7/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s8/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s9/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s10/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s11/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_300/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s12/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_300/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s13/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_300/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s14/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/water_blank_300/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s15/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s16/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s17/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s18/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s19/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_300/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s20/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_300/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s21/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_300/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s22/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_300/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s23/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s24/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s25/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s26/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s27/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_25/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s28/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_25/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s29/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_25/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s30/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_25/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s31/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_12_5/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s32/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_12_5/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s33/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_12_5/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s34/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_12_5/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s35/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_50/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s36/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_50/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s37/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_50/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s38/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_50/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s39/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_203125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s40/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_203125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s41/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_203125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s42/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_203125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s43/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_025390625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s44/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_025390625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s45/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_025390625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s46/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_025390625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s47/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_40625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s48/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_40625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s49/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_40625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s50/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_40625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s51/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_1_625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s52/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_1_625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s53/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_1_625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s54/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_1_625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s55/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_8125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s56/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_8125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s57/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_8125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s58/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_8125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s59/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_1015625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s60/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_1015625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s61/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_1015625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s62/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_1015625/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s63/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_05078125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s64/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_05078125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s65/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_05078125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s66/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_05078125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s67/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_6_25/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s68/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_6_25/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s69/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_6_25/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s70/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_6_25/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s71/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_3_125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s72/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_3_125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s73/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_3_125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s74/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/fluorescein_control_3_125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s76/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s77/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s78/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s79/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s80/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "provide": [
+                                    "https://sd2e.org#bead_model",
+                                    "https://sd2e.org#bead_batch"
+                                ],
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s1/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/beads_spherotech_pps_6K/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "provide": [
+                                    "https://sd2e.org#bead_model",
+                                    "https://sd2e.org#bead_batch"
+                                ],
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s2/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/design/beads_spherotech_rainbow/1"
+                            }
+                        ]
+                    }
+                ],
+                "type": "provision"
+            }
+        },
+        {
+            "id": 1,
+            "name": "Step 1",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 1,
+                "name": "Streak Operator",
+                "transformations": [
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s80/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s79/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s78/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s77/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s76/1"
+                            }
+                        ]
+                    }
+                ],
+                "type": "streak"
+            }
+        },
+        {
+            "id": 2,
+            "name": "Step 2",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 2,
+                "name": "Incubate Operator",
+                "parameters": [
+                    {
+                        "duration": "2:day"
+                    },
+                    {
+                        "temperature": "30:centrigrade"
+                    }
+                ],
+                "samples": [
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81/1"
+                ],
+                "type": "incubate"
+            }
+        },
+        {
+            "id": 3,
+            "name": "Step 3",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 3,
+                "name": "Pick Operator",
+                "transformations": [
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "200:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85/1"
+                            }
+                        ]
+                    }
+                ],
+                "type": "pick"
+            }
+        },
+        {
+            "id": 4,
+            "name": "Step 4",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 4,
+                "name": "Incubate Operator",
+                "parameters": [
+                    {
+                        "duration": "1:hour"
+                    },
+                    {
+                        "temperature": "30:centrigrade"
+                    },
+                    {
+                        "rpm": "800:rpm"
+                    },
+                    {
+                        "throw": "3:millimeter"
+                    }
+                ],
+                "samples": [
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115/1"
+                ],
+                "type": "incubate"
+            }
+        },
+        {
+            "id": 5,
+            "name": "Step 5",
+            "operator": {
+                "id": 5,
+                "instrument_configuration": "agave://data-sd2e-community/biofab/instruments/synergy_ht/216503/03132018/platereader_configuration.json",
+                "manifest": "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/manifest/manifest.json",
+                "measurements": [
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s74/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s73/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s72/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s71/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s70/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s69/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s68/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s67/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s66/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s65/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s64/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s63/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s62/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s61/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s60/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s59/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s58/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s57/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s56/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s55/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s54/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s53/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s52/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s51/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s50/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s49/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s48/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s47/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s46/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s45/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s44/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s43/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s42/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s41/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s40/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s39/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s38/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s37/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s36/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s35/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s34/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s33/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s32/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s31/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s30/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s29/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s28/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s27/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s26/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s25/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s24/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s23/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s22/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s21/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s20/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s19/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s18/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s17/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s16/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s15/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s14/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s13/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s12/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s11/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s10/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s9/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s8/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s7/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s6/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s5/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s4/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s3/1"
+                            }
+                        ]
+                    }
+                ],
+                "name": "Spectrophotometry Operator",
+                "type": "spectrophotometry"
+            }
+        },
+        {
+            "id": 6,
+            "name": "Step 6",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 6,
+                "name": "Dilute Operator",
+                "transformations": [
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.0003
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 0.00015
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116/1"
+                            },
+                            {
+                                "attribute": {
+                                    "od600": 7.5e-05
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86/1"
+                            }
+                        ]
+                    }
+                ],
+                "type": "dilute"
+            }
+        },
+        {
+            "id": 7,
+            "name": "Step 7",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 7,
+                "name": "Incubate Operator",
+                "parameters": [
+                    {
+                        "duration": "16:hour"
+                    },
+                    {
+                        "temperature": "30:centigrade"
+                    },
+                    {
+                        "rpm": "800:rpm"
+                    },
+                    {
+                        "throw": "3:millimeter"
+                    }
+                ],
+                "samples": [
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205/1"
+                ],
+                "type": "incubate"
+            }
+        },
+        {
+            "id": 8,
+            "name": "Step 8",
+            "operator": {
+                "comment": "...",
+                "description": "",
+                "id": 8,
+                "name": "Transfer Operator",
+                "transformations": [
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205_R295/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204_R294/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203_R293/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202_R292/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201_R291/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200_R290/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199_R289/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198_R288/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197_R287/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196_R286/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195_R285/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194_R284/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193_R283/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192_R282/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191_R281/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190_R280/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189_R279/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188_R278/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187_R277/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186_R276/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185_R275/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184_R274/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183_R273/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182_R272/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181_R271/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180_R270/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179_R269/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178_R268/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177_R267/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176_R266/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175_R265/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174_R264/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173_R263/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172_R262/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171_R261/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170_R260/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169_R259/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168_R258/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167_R257/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166_R256/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165_R255/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164_R254/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163_R253/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162_R252/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161_R251/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160_R250/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159_R249/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158_R248/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157_R247/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156_R246/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155_R245/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154_R244/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153_R243/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152_R242/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151_R241/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150_R240/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149_R239/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148_R238/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147_R237/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146_R236/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145_R235/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144_R234/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143_R233/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142_R232/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141_R231/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140_R230/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139_R229/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138_R228/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137_R227/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136_R226/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135_R225/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134_R224/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133_R223/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132_R222/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131_R221/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130_R220/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129_R219/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128_R218/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127_R217/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126_R216/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125_R215/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124_R214/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123_R213/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122_R212/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121_R211/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120_R210/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119_R209/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118_R208/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117_R207/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116_R206/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s0/1"
+                            },
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75_R296/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "attribute": {
+                                    "volume": "300:microliter"
+                                },
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s2_R298/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s2/1"
+                            }
+                        ]
+                    },
+                    {
+                        "destination": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s1_R297/1"
+                            }
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s1/1"
+                            }
+                        ]
+                    }
+                ],
+                "type": "transfer"
+            }
+        },
+        {
+            "id": 9,
+            "name": "Step 9",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 9,
+                "name": "Mix Operator",
+                "samples": [
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116_R206/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117_R207/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118_R208/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119_R209/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120_R210/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121_R211/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122_R212/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123_R213/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124_R214/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125_R215/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126_R216/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127_R217/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128_R218/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129_R219/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130_R220/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131_R221/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132_R222/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133_R223/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134_R224/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135_R225/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136_R226/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137_R227/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138_R228/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139_R229/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140_R230/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141_R231/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142_R232/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143_R233/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144_R234/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145_R235/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146_R236/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147_R237/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148_R238/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149_R239/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150_R240/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151_R241/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152_R242/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153_R243/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154_R244/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155_R245/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156_R246/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157_R247/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158_R248/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159_R249/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160_R250/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161_R251/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162_R252/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163_R253/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164_R254/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165_R255/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166_R256/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167_R257/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168_R258/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169_R259/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170_R260/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171_R261/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172_R262/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173_R263/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174_R264/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175_R265/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176_R266/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177_R267/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178_R268/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179_R269/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180_R270/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181_R271/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182_R272/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183_R273/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184_R274/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185_R275/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186_R276/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187_R277/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188_R278/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189_R279/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190_R280/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191_R281/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192_R282/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193_R283/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194_R284/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195_R285/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196_R286/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197_R287/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198_R288/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199_R289/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200_R290/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201_R291/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202_R292/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203_R293/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204_R294/1",
+                    "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205_R295/1"
+                ],
+                "type": "mix"
+            }
+        },
+        {
+            "id": 10,
+            "name": "Step 10",
+            "operator": {
+                "id": 10,
+                "instrument_configuration": "agave://data-sd2e-community/biofab/instruments/synergy_ht/216503/03132018/platereader_configuration.json",
+                "manifest": "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/manifest/manifest.json",
+                "measurements": [
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116_R206/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117_R207/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118_R208/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119_R209/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120_R210/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121_R211/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122_R212/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123_R213/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124_R214/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125_R215/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126_R216/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127_R217/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128_R218/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129_R219/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130_R220/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131_R221/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132_R222/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133_R223/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134_R224/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135_R225/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136_R226/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137_R227/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138_R228/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139_R229/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140_R230/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141_R231/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142_R232/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143_R233/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144_R234/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145_R235/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146_R236/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147_R237/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148_R238/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149_R239/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150_R240/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151_R241/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152_R242/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153_R243/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154_R244/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155_R245/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156_R246/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157_R247/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158_R248/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159_R249/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160_R250/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161_R251/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162_R252/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163_R253/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164_R254/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165_R255/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166_R256/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167_R257/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168_R258/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169_R259/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170_R260/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171_R261/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172_R262/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173_R263/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174_R264/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175_R265/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176_R266/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177_R267/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178_R268/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179_R269/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180_R270/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181_R271/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182_R272/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183_R273/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184_R274/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185_R275/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186_R276/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187_R277/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188_R278/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189_R279/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190_R280/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191_R281/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192_R282/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193_R283/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194_R284/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195_R285/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196_R286/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197_R287/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198_R288/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199_R289/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200_R290/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201_R291/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202_R292/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203_R293/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204_R294/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205_R295/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75_R296/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s74/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s73/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s72/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s71/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s70/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s69/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s68/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s67/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s66/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s65/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s64/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s63/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s62/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s61/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s60/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s59/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s58/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s57/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s56/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s55/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s54/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s53/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s52/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s51/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s50/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s49/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s48/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s47/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s46/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s45/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s44/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s43/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s42/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s41/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s40/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s39/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s38/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s37/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s36/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s35/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s34/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s33/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s32/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s31/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s30/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s29/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s28/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s27/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s26/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s25/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s24/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s23/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s22/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s21/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s20/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s19/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s18/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s17/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s16/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s15/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s14/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s13/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s12/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s11/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s10/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s9/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s8/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s7/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s6/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s5/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s4/1"
+                            },
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s3/1"
+                            }
+                        ]
+                    }
+                ],
+                "name": "Spectrophotometry Operator",
+                "type": "spectrophotometry"
+            }
+        },
+        {
+            "id": 11,
+            "name": "Step 11",
+            "operator": {
+                "comment": "...",
+                "description": "...",
+                "id": 11,
+                "instrument_configuration": "agave://data-sd2e-community/biofab/instruments/accuri/5539/11272017/cytometer_configuration.json",
+                "manifest": "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/manifest/manifest.json",
+                "measurements": [
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R86_R116_R206.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116_R206/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R86_R117_R207.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117_R207/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R86_R118_R208.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118_R208/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R87_R119_R209.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119_R209/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R87_R120_R210.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120_R210/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R87_R121_R211.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121_R211/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R88_R122_R212.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122_R212/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R88_R123_R213.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123_R213/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R88_R124_R214.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124_R214/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R89_R125_R215.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125_R215/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R89_R126_R216.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126_R216/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R89_R127_R217.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127_R217/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R90_R128_R218.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128_R218/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R90_R129_R219.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129_R219/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R90_R130_R220.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130_R220/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R91_R131_R221.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131_R221/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R91_R132_R222.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132_R222/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R91_R133_R223.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133_R223/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R92_R134_R224.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134_R224/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R92_R135_R225.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135_R225/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R92_R136_R226.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136_R226/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R93_R137_R227.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137_R227/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R93_R138_R228.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138_R228/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R93_R139_R229.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139_R229/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R94_R140_R230.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140_R230/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R94_R141_R231.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141_R231/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R94_R142_R232.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142_R232/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R95_R143_R233.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143_R233/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R95_R144_R234.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144_R234/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R95_R145_R235.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145_R235/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R96_R146_R236.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146_R236/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R96_R147_R237.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147_R237/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R96_R148_R238.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148_R238/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R97_R149_R239.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149_R239/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R97_R150_R240.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150_R240/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R97_R151_R241.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151_R241/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R98_R152_R242.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152_R242/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R98_R153_R243.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153_R243/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R98_R154_R244.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154_R244/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R99_R155_R245.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155_R245/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R99_R156_R246.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156_R246/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R99_R157_R247.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157_R247/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R100_R158_R248.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158_R248/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R100_R159_R249.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159_R249/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R100_R160_R250.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160_R250/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R101_R161_R251.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161_R251/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R101_R162_R252.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162_R252/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R101_R163_R253.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163_R253/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R102_R164_R254.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164_R254/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R102_R165_R255.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165_R255/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R102_R166_R256.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166_R256/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R103_R167_R257.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167_R257/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R103_R168_R258.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168_R258/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R103_R169_R259.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169_R259/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R104_R170_R260.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170_R260/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R104_R171_R261.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171_R261/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R104_R172_R262.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172_R262/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R105_R173_R263.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173_R263/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R105_R174_R264.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174_R264/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R105_R175_R265.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175_R265/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R106_R176_R266.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176_R266/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R106_R177_R267.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177_R267/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R106_R178_R268.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178_R268/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R107_R179_R269.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179_R269/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R107_R180_R270.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180_R270/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R107_R181_R271.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181_R271/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R108_R182_R272.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182_R272/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R108_R183_R273.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183_R273/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R108_R184_R274.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184_R274/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R109_R185_R275.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185_R275/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R109_R186_R276.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186_R276/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R109_R187_R277.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187_R277/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R110_R188_R278.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188_R278/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R110_R189_R279.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189_R279/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R110_R190_R280.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190_R280/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R111_R191_R281.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191_R281/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R111_R192_R282.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192_R282/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R111_R193_R283.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193_R283/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R112_R194_R284.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194_R284/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R112_R195_R285.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195_R285/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R112_R196_R286.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196_R286/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R113_R197_R287.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197_R287/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R113_R198_R288.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198_R288/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R113_R199_R289.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199_R289/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R114_R200_R290.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200_R290/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R114_R201_R291.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201_R291/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R114_R202_R292.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202_R292/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R115_R203_R293.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203_R293/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R115_R204_R294.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204_R294/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R115_R205_R295.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205_R295/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s1_R297.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s1_R297/1"
+                            }
+                        ]
+                    },
+                    {
+                        "file": [
+                            "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s2_R298.fcs"
+                        ],
+                        "source": [
+                            {
+                                "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s2_R298/1"
+                            }
+                        ]
+                    }
+                ],
+                "name": "Flow Operator",
+                "type": "flow_cytometry"
+            }
+        }
+    ]
+}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='xplan_to_sbol',
       version='0.1',
       description='Converter from XPLAN JSON format to SBOL.',
-      url='https://github.com/SD2E/data-representation/sbol/xplan_to_sbol',
+      url='https://github.com/SD2E/xplan_to_sbol',
       author='Nicholas Roehner',
       author_email='nicholasroehner@gmail.com',
       packages=['xplan_to_sbol'],
@@ -13,9 +13,9 @@ setup(name='xplan_to_sbol',
           ]
       },
       install_requires=[
-          'pySBOLx'
+        'synbiohub_adapter==0.0.1', 'sparqlwrapper'
       ],
       dependency_links=[
-        'git+https://git@github.com/nroehner/pySBOLx.git#egg=pySBOLx'
+        'git+https://git@github.com/SD2E/synbiohub_adapter.git#egg=synbiohub_adapter-0.0.1'
       ],
       zip_safe=False)

--- a/tests/Test_YG_Intent_Controls.py
+++ b/tests/Test_YG_Intent_Controls.py
@@ -1,0 +1,44 @@
+
+import json
+import pySBOLx
+import unittest
+import sys
+import argparse
+from xplan_to_sbol.ConversionUtil import *
+from xplan_to_sbol.xplanParser.XplanDataParser import XplanDataParser
+
+import xplan_to_sbol.__main__ as xbol
+from sbol import *
+
+""" 
+    This module is used to test data uploaded through xplan to sbol for the YG challenge problem.
+    author(s) : Mark Weston
+"""
+class TestYeastGates(unittest.TestCase):
+
+    """ 
+    This uploads a dummy YG plan's intent, WT, and control information
+    """
+    def test_intent_control_upload(self):
+        yg_json = 'example/xplan/biofab_yg_UWBF_NOR_intent_control_test.json'        
+        
+        with open(yg_json) as json_file:
+            json_data = json.load(json_file)
+
+            # change this manually with the SBH password; getting unittest to accept custom 
+            # arguments is a pain
+            #FIXME: parameterize this
+            password = None
+            if password is not None:
+                uploaded = xbol.post_upload_intent(json_data, 'https://hub.sd2e.org', 'sd2_service@sd2e.org', password)
+                self.assertTrue(uploaded)
+
+                self.assertTrue(xbol.read_intent(json_data))
+            else:
+                print("No password provided, skipping upload")
+            control_results = xbol.post_upload_controls(json_data)
+            # We should have written two triple sets
+            self.assertTrue(len(control_results['results']['bindings']) == 2)
+            
+if __name__ == '__main__':
+    unittest.main()

--- a/xplan_to_sbol/__main__.py
+++ b/xplan_to_sbol/__main__.py
@@ -1,8 +1,11 @@
 import argparse
 import json
 import sys
+import os
 from urllib.parse import urlparse
 from pySBOLx.pySBOLx import XDocument
+from synbiohub_adapter.upload_sbol import SynBioHub
+from SPARQLWrapper import SPARQLWrapper, JSON
 
 SD2_NS = 'http://hub.sd2e.org/user/sd2e'
 SD2S_NS = 'https://hub.sd2e.org/user/sd2e'
@@ -685,6 +688,140 @@ def convert_xplan_to_sbol(plan_data, plan_path, exp_path, om_path, validate, nam
 
     return (plan_doc, exp_doc)
 
+"""
+Does the intent already exist? e.g. for re-upload
+"""
+def read_intent(plan_data):
+
+    plan_id = plan_data['id']
+    intent_file_name = plan_data['experiment_id'] + '_intent.json'
+
+    sparql = SPARQLWrapper("https://hub-api.sd2e.org/sparql")
+    query = """
+    select ?attachment_name where
+    {{
+      <{}> <http://wiki.synbiohub.org/wiki/Terms/synbiohub#attachment> ?attachment_id .
+      ?attachment_id <http://purl.org/dc/terms/title> ?attachment_name .
+    }}
+    """.format(plan_id)
+
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+    
+    if len(results['results']['bindings']) != 0:
+        for attachment_value in results['results']['bindings']:
+            found_attachment_name = attachment_value['attachment_name']['value']
+            if intent_file_name == found_attachment_name:
+                print("Already found attachment, skipping")
+                return True
+    return False
+
+"""
+Link the plan's intent to the plan URI as an attachment
+Skips the attachment if a file already exists with the same name
+"""
+def post_upload_intent(plan_data, url, email, password):
+
+    found_intent = read_intent(plan_data)
+    if found_intent:
+        return True
+
+    plan_id = plan_data['id']
+    intent_data = plan_data['intent']
+    intent_file_name = plan_data['experiment_id'] + '_intent.json'
+
+    sbh = SynBioHub(url,
+                    email,
+                    password,
+                    'http://hub-api.sd2e.org:80/sparql',
+                    {'http://sd2e.org#bead_model', 'http://sd2e.org#bead_batch'})
+
+    print("Attaching intent")
+    with open(intent_file_name, "w") as outfile:
+        json.dump(intent_data, outfile)
+
+    sbh.attach_file(intent_file_name, plan_id)
+    os.remove(intent_file_name)
+    return True
+
+"""
+Link some control information, if known: beads, wild-type to the plan URI
+This supports plan-automated FCS processing
+"""
+def post_upload_controls(plan_data):
+
+    plan_id = plan_data['id']
+    sparql = SPARQLWrapper("https://hub-api.sd2e.org/sparql")
+
+    save_bead_uri = None
+    save_wt_uri = None
+
+    # look up bead samples for plan
+    query = """
+    select distinct ?sample where
+    {{
+      <{}> <http://sd2e.org#experimentalData> ?data .
+      ?data <http://www.w3.org/ns/prov#wasDerivedFrom>+ <https://hub.sd2e.org/user/sd2e/design/beads_spherotech_rainbow/1> .
+      ?data <http://www.w3.org/ns/prov#wasDerivedFrom> ?sample .
+    }}
+    """.format(plan_id)
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()['results']['bindings']
+    for result in results:
+      bead_uri = result['sample']['value']
+      if save_bead_uri == None:
+        save_bead_uri = bead_uri
+
+    # look up WT for plan
+    # NCIT_C62195 is the ontology term for a wild type design
+    query = """
+    select distinct ?sample where
+    {{
+      <{}> <http://sd2e.org#experimentalData> ?data .
+      ?sample <http://sbols.org/v2#role> <http://purl.obolibrary.org/obo/NCIT_C62195> .
+      ?data <http://www.w3.org/ns/prov#wasDerivedFrom>+ ?sample .
+    }}
+    """.format(plan_id)
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()['results']['bindings']
+    for result in results:
+      wt_uri = result['sample']['value']
+      if save_wt_uri == None:
+        save_wt_uri = wt_uri
+
+    if save_bead_uri != None:
+      print("Writing bead control: " + plan_id + " " + save_bead_uri)
+
+      query = """
+      WITH <https://hub.sd2e.org/user/sd2e> 
+      INSERT {{
+      <{}> <http://sd2e.org#bead_control> <{}> .
+      }}""".format(plan_id, save_bead_uri)
+      sparql.setQuery(query)
+      sparql.setReturnFormat(JSON)
+      bead_write_results = sparql.query().convert()
+      print(bead_write_results)
+
+    if save_wt_uri != None:
+      print("Writing wild type as negative control: " + plan_id + " " + save_wt_uri)
+
+      query = """
+      WITH <https://hub.sd2e.org/user/sd2e>
+      INSERT {{
+      <{}> <http://sd2e.org#negative_control> <{}> .
+      }} 
+      """.format(plan_id, save_wt_uri)
+      sparql.setQuery(query)
+      sparql.setReturnFormat(JSON)
+      wt_write_results = sparql.query().convert()
+      print(wt_write_results)
+
+      bead_write_results['results']['bindings'].extend(wt_write_results['results']['bindings'])
+      return bead_write_results
+
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
@@ -725,6 +862,9 @@ def main(args=None):
             else:
                 docs[1].upload(args.url, args.email, args.password, SD2_EXP_COLLECTION, 2)
                 print('Plan uploaded.')
+
+            post_upload_intent(plan_data, args.url, args.email, args.password)
+            post_upload_controls(plan_data)
 
     print('done')
 


### PR DESCRIPTION
@nroehner this adds some "post" upload functions that:

- Attach the plan's intent as a JSON attachment
- Attempts to look up bead and wild type information, linking these to the plan URI using the existing predicates we use for FCS-ETL.

All three of these pieces of information have been stitched in manually to date. Having them occur automatically on upload will be a _significant_ benefit to new plans. I've tried to make this idempotent where possible:

1) Detecting when the attachment already exists, and not adding it
2) The predicates are simple triples and can safely overrwrite.

I added a test case to help exercise these functions and it works using a test plan I created. I struggled a bit to jam the SBH password into something unittest could accept over the command line, so for now I just edit that manually when I want to test it. 

I also fixed some issues in the setup.py so it installs SBH, which automatically pulls in everything else it needs.

All of this occurs _after_ the SBOL upload, as I believe we need the URI/document, etc. in place to do the attachment process.

Feedback on any of this is welcome. Thanks!

Example output:

```
No password provided, skipping upload
Writing bead control: https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1 https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s2_R298/1
/Users/markweston/Documents/Netrias/jenkins-integration/xplan_to_sbol/py3/lib/python3.6/site-packages/SPARQLWrapper/Wrapper.py:700: UserWarning: update operations MUST be done by POST
  warnings.warn("update operations MUST be done by POST")
{'head': {'link': [], 'vars': ['callret-0']}, 'results': {'distinct': False, 'ordered': True, 'bindings': [{'callret-0': {'type': 'literal', 'value': 'Insert into <https://hub.sd2e.org/user/sd2e>, 1 (or less) triples -- done'}}]}}
Writing wild type as negative control: https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1 https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1
{'head': {'link': [], 'vars': ['callret-0']}, 'results': {'distinct': False, 'ordered': True, 'bindings': [{'callret-0': {'type': 'literal', 'value': 'Insert into <https://hub.sd2e.org/user/sd2e>, 1 (or less) triples -- done'}}]}}
.
----------------------------------------------------------------------
Ran 1 test in 1.355s

OK
```