### PR TITLE
Add support for attaching plan JSON and sample attributes; refactor some common upload functions, fix for multiple bead controls (TX does this in their YG plans)

### DIFF
--- a/example/xplan/biofab_yg_UWBF_NOR_intent_control_test_sample_attributes.json
+++ b/example/xplan/biofab_yg_UWBF_NOR_intent_control_test_sample_attributes.json
@@ -1,0 +1,5983 @@
+[
+    {
+        "design_attributes": {},
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s2_R298/1",
+        "sample_attributes": {
+            "bead_colony": "https://hub.sd2e.org/user/sd2e/design/beads_spherotech_rainbow/1",
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s2_R298.fcs"
+            ],
+            "parent": "s2",
+            "replicate": 0
+        }
+    },
+    {
+        "design_attributes": {},
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s1_R297/1",
+        "sample_attributes": {
+            "bead_colony": "https://hub.sd2e.org/user/sd2e/design/beads_spherotech_pps_6K/1",
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s1_R297.fcs"
+            ],
+            "parent": "s1",
+            "replicate": 0
+        }
+    },
+    {
+        "design_attributes": {
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s75_R296/1",
+        "sample_attributes": {
+            "blank": "True",
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "parent": "s75",
+            "replicate": 0
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R205_R295/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R115_R205_R295.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s81_R115_R205",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R204_R294/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R115_R204_R294.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s81_R115_R204",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115_R203_R293/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R115_R203_R293.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s81_R115_R203",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R202_R292/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R114_R202_R292.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s81_R114_R202",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R201_R291/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R114_R201_R291.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s81_R114_R201",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114_R200_R290/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R114_R200_R290.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s81_R114_R200",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R199_R289/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R113_R199_R289.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s81_R113_R199",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R198_R288/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R113_R198_R288.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s81_R113_R198",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113_R197_R287/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R113_R197_R287.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s81_R113_R197",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R196_R286/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R112_R196_R286.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s81_R112_R196",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R195_R285/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R112_R195_R285.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s81_R112_R195",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112_R194_R284/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R112_R194_R284.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s81_R112_R194",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R193_R283/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R111_R193_R283.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s81_R111_R193",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R192_R282/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R111_R192_R282.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s81_R111_R192",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111_R191_R281/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R111_R191_R281.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s81_R111_R191",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R190_R280/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R110_R190_R280.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s81_R110_R190",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R189_R279/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R110_R189_R279.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s81_R110_R189",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110_R188_R278/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s81_R110_R188_R278.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s81_R110_R188",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R187_R277/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R109_R187_R277.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s82_R109_R187",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R186_R276/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R109_R186_R276.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s82_R109_R186",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109_R185_R275/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R109_R185_R275.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s82_R109_R185",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R184_R274/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R108_R184_R274.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s82_R108_R184",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R183_R273/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R108_R183_R273.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s82_R108_R183",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108_R182_R272/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R108_R182_R272.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s82_R108_R182",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R181_R271/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R107_R181_R271.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s82_R107_R181",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R180_R270/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R107_R180_R270.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s82_R107_R180",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107_R179_R269/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R107_R179_R269.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s82_R107_R179",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R178_R268/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R106_R178_R268.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s82_R106_R178",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R177_R267/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R106_R177_R267.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s82_R106_R177",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106_R176_R266/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R106_R176_R266.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s82_R106_R176",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R175_R265/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R105_R175_R265.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s82_R105_R175",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R174_R264/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R105_R174_R264.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s82_R105_R174",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105_R173_R263/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R105_R173_R263.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s82_R105_R173",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R172_R262/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R104_R172_R262.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s82_R104_R172",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R171_R261/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R104_R171_R261.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s82_R104_R171",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104_R170_R260/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s82_R104_R170_R260.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s82_R104_R170",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R169_R259/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R103_R169_R259.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s83_R103_R169",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R168_R258/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R103_R168_R258.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s83_R103_R168",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103_R167_R257/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R103_R167_R257.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s83_R103_R167",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R166_R256/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R102_R166_R256.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s83_R102_R166",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R165_R255/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R102_R165_R255.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s83_R102_R165",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102_R164_R254/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R102_R164_R254.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s83_R102_R164",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R163_R253/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R101_R163_R253.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s83_R101_R163",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R162_R252/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R101_R162_R252.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s83_R101_R162",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101_R161_R251/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R101_R161_R251.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s83_R101_R161",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R160_R250/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R100_R160_R250.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s83_R100_R160",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R159_R249/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R100_R159_R249.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s83_R100_R159",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100_R158_R248/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R100_R158_R248.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s83_R100_R158",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R157_R247/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R99_R157_R247.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s83_R99_R157",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R156_R246/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R99_R156_R246.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s83_R99_R156",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99_R155_R245/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R99_R155_R245.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s83_R99_R155",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R154_R244/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R98_R154_R244.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s83_R98_R154",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R153_R243/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R98_R153_R243.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s83_R98_R153",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98_R152_R242/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s83_R98_R152_R242.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s83_R98_R152",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R151_R241/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R97_R151_R241.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s84_R97_R151",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R150_R240/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R97_R150_R240.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s84_R97_R150",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97_R149_R239/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R97_R149_R239.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s84_R97_R149",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R148_R238/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R96_R148_R238.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s84_R96_R148",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R147_R237/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R96_R147_R237.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s84_R96_R147",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96_R146_R236/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R96_R146_R236.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s84_R96_R146",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R145_R235/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R95_R145_R235.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s84_R95_R145",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R144_R234/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R95_R144_R234.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s84_R95_R144",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95_R143_R233/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R95_R143_R233.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s84_R95_R143",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R142_R232/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R94_R142_R232.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s84_R94_R142",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R141_R231/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R94_R141_R231.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s84_R94_R141",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94_R140_R230/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R94_R140_R230.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s84_R94_R140",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R139_R229/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R93_R139_R229.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s84_R93_R139",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R138_R228/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R93_R138_R228.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s84_R93_R138",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93_R137_R227/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R93_R137_R227.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s84_R93_R137",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R136_R226/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R92_R136_R226.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s84_R92_R136",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R135_R225/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R92_R135_R225.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s84_R92_R135",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92_R134_R224/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s84_R92_R134_R224.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s84_R92_R134",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R133_R223/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R91_R133_R223.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s85_R91_R133",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R132_R222/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R91_R132_R222.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s85_R91_R132",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91_R131_R221/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R91_R131_R221.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s85_R91_R131",
+            "replicate": 4,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R130_R220/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R90_R130_R220.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s85_R90_R130",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R129_R219/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R90_R129_R219.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s85_R90_R129",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90_R128_R218/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R90_R128_R218.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s85_R90_R128",
+            "replicate": 5,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R127_R217/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R89_R127_R217.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s85_R89_R127",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R126_R216/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R89_R126_R216.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s85_R89_R126",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89_R125_R215/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R89_R125_R215.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s85_R89_R125",
+            "replicate": 1,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R124_R214/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R88_R124_R214.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s85_R88_R124",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R123_R213/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R88_R123_R213.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s85_R88_R123",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88_R122_R212/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R88_R122_R212.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s85_R88_R122",
+            "replicate": 2,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R121_R211/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R87_R121_R211.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s85_R87_R121",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R120_R210/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R87_R120_R210.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s85_R87_R120",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87_R119_R209/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R87_R119_R209.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s85_R87_R119",
+            "replicate": 3,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R118_R208/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R86_R118_R208.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.0003,
+            "parent": "s85_R86_R118",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R117_R207/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R86_R117_R207.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 0.00015,
+            "parent": "s85_R86_R117",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 9,
+                    "name": "Mix Operator",
+                    "parameters": null,
+                    "type": "mix"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 10,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 11,
+                    "name": "Flow Operator",
+                    "parameters": null,
+                    "type": "flow_cytometry"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86_R116_R206/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/3/instrument_output/s85_R86_R116_R206.fcs",
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/2/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "od": 7.5e-05,
+            "parent": "s85_R86_R116",
+            "replicate": 0,
+            "stain": "https://hub.sd2e.org/user/sd2e/design/CAT_S34859/1",
+            "timepoint": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R115/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s81",
+            "replicate": 4
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R114/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s81",
+            "replicate": 5
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R113/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s81",
+            "replicate": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R112/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s81",
+            "replicate": 2
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R111/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s81",
+            "replicate": 3
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6389/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s81_R110/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s81",
+            "replicate": 0
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R109/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s82",
+            "replicate": 4
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R108/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s82",
+            "replicate": 5
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R107/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s82",
+            "replicate": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R106/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s82",
+            "replicate": 2
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R105/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s82",
+            "replicate": 3
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6390/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s82_R104/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s82",
+            "replicate": 0
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R103/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s83",
+            "replicate": 4
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R102/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s83",
+            "replicate": 5
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R101/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s83",
+            "replicate": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R100/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s83",
+            "replicate": 2
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R99/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s83",
+            "replicate": 3
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6391/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s83_R98/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s83",
+            "replicate": 0
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R97/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s84",
+            "replicate": 4
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R96/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s84",
+            "replicate": 5
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R95/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s84",
+            "replicate": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R94/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s84",
+            "replicate": 2
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R93/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s84",
+            "replicate": 3
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBF_6388/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s84_R92/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s84",
+            "replicate": 0
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R91/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s85",
+            "replicate": 4
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R90/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s85",
+            "replicate": 5
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R89/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s85",
+            "replicate": 1
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R88/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s85",
+            "replicate": 2
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R87/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s85",
+            "replicate": 3
+        }
+    },
+    {
+        "design_attributes": {
+            "strain": "https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1"
+        },
+        "operators": [
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 4,
+                    "name": "Incubate Operator",
+                    "parameters": [
+                        {
+                            "duration": "1:hour"
+                        },
+                        {
+                            "temperature": "30:centrigrade"
+                        },
+                        {
+                            "rpm": "800:rpm"
+                        },
+                        {
+                            "throw": "3:millimeter"
+                        }
+                    ],
+                    "type": "incubate"
+                }
+            },
+            {
+                "operator": {
+                    "description": null,
+                    "id": 5,
+                    "name": "Spectrophotometry Operator",
+                    "parameters": null,
+                    "type": "spectrophotometry"
+                }
+            },
+            {
+                "operator": {
+                    "description": "...",
+                    "id": 6,
+                    "name": "Dilute Operator",
+                    "parameters": null,
+                    "type": "dilute"
+                }
+            }
+        ],
+        "sample": "https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s85_R86/1",
+        "sample_attributes": {
+            "files": [
+                "agave://data-sd2e-community/biofab/yeast-gates_q0/intent_control_test/1/instrument_output/od.csv"
+            ],
+            "media": "https://hub.sd2e.org/user/sd2e/design/culture_media_5/1",
+            "parent": "s85",
+            "replicate": 0
+        }
+    }
+]

--- a/tests/Test_YG_Intent_Controls.py
+++ b/tests/Test_YG_Intent_Controls.py
@@ -3,6 +3,7 @@ import json
 import pySBOLx
 import unittest
 import sys
+import os
 import argparse
 from xplan_to_sbol.ConversionUtil import *
 from xplan_to_sbol.xplanParser.XplanDataParser import XplanDataParser
@@ -17,26 +18,51 @@ from sbol import *
 class TestYeastGates(unittest.TestCase):
 
     """ 
-    This uploads a dummy YG plan's intent, WT, and control information
+    This uploads a dummy YG plan's plan, sample attributes, intent, WT, and control information
     """
     def test_intent_control_upload(self):
-        yg_json = 'example/xplan/biofab_yg_UWBF_NOR_intent_control_test.json'        
-        
-        with open(yg_json) as json_file:
-            json_data = json.load(json_file)
+        yg_json_path = 'example/xplan/biofab_yg_UWBF_NOR_intent_control_test.json'
+        yg_json_sa_path = 'example/xplan/biofab_yg_UWBF_NOR_intent_control_test_sample_attributes.json'
+
+        url = 'https://hub.sd2e.org'
+        email = 'sd2_service@sd2e.org'
+
+        with open(yg_json_path) as plan_json_file:
+            plan_data = json.load(plan_json_file)
 
             # change this manually with the SBH password; getting unittest to accept custom 
             # arguments is a pain
             #FIXME: parameterize this
             password = None
             if password is not None:
-                uploaded = xbol.post_upload_intent(json_data, 'https://hub.sd2e.org', 'sd2_service@sd2e.org', password)
-                self.assertTrue(uploaded)
 
-                self.assertTrue(xbol.read_intent(json_data))
+                # intent
+                plan_base_name = os.path.basename(yg_json_path)
+                plan_id = plan_data['id']
+                intent = plan_data['intent']
+                intent_file_name = xbol.create_intent_file_name(plan_base_name)
+
+                uploaded = xbol.post_upload_json(plan_id, intent, intent_file_name, url, email, password)
+                self.assertTrue(uploaded)
+                self.assertTrue(xbol.read_attachment(plan_id, intent_file_name))
+
+                # plan
+                uploaded = xbol.post_upload_json(plan_id, plan_data, plan_base_name, url, email, password)
+                self.assertTrue(uploaded)
+                self.assertTrue(xbol.read_attachment(plan_id, plan_base_name))
+
+                # sample attributes
+                sample_attributes_file_name = xbol.create_sample_attributes_file_name(plan_base_name)
+
+                with open(yg_json_sa_path) as plan_sample_attributes_file:
+                    plan_sample_attributes_data = json.load(plan_sample_attributes_file)
+                    uploaded = xbol.post_upload_json(plan_id, plan_sample_attributes_data, sample_attributes_file_name, url, email, password)
+                    self.assertTrue(uploaded)
+                    self.assertTrue(xbol.read_attachment(plan_id, sample_attributes_file_name))
             else:
                 print("No password provided, skipping upload")
-            control_results = xbol.post_upload_controls(json_data)
+
+            control_results = xbol.post_upload_controls(plan_data)
             # We should have written two triple sets
             self.assertTrue(len(control_results['results']['bindings']) == 2)
             

--- a/xplan_to_sbol/__main__.py
+++ b/xplan_to_sbol/__main__.py
@@ -870,7 +870,8 @@ def main(args=None):
             plan_base_name = os.path.basename(args.input)
             plan_id = plan_data["id"]
 
-            post_upload_json(plan_id, plan_data["intent"], create_intent_file_name(plan_base_name), args.url, args.email, args.password)
+            if "intent" in plan_data and plan_data["intent"] is not None:
+                post_upload_json(plan_id, plan_data["intent"], create_intent_file_name(plan_base_name), args.url, args.email, args.password)
             
             post_upload_controls(plan_data)
 

--- a/xplan_to_sbol/__main__.py
+++ b/xplan_to_sbol/__main__.py
@@ -695,12 +695,9 @@ def convert_xplan_to_sbol(plan_data, plan_path, exp_path, om_path, validate, nam
     return (plan_doc, exp_doc)
 
 """
-Does the intent already exist? e.g. for re-upload
+Does the attachment already exist? e.g. for re-upload
 """
-def read_intent(plan_data):
-
-    plan_id = plan_data['id']
-    intent_file_name = plan_data['experiment_id'] + '_intent.json'
+def read_attachment(uri, json_file_name):
 
     sparql = SPARQLWrapper("https://hub-api.sd2e.org/sparql")
     query = """
@@ -709,7 +706,7 @@ def read_intent(plan_data):
       <{}> <http://wiki.synbiohub.org/wiki/Terms/synbiohub#attachment> ?attachment_id .
       ?attachment_id <http://purl.org/dc/terms/title> ?attachment_name .
     }}
-    """.format(plan_id)
+    """.format(uri)
 
     sparql.setQuery(query)
     sparql.setReturnFormat(JSON)
@@ -718,24 +715,25 @@ def read_intent(plan_data):
     if len(results['results']['bindings']) != 0:
         for attachment_value in results['results']['bindings']:
             found_attachment_name = attachment_value['attachment_name']['value']
-            if intent_file_name == found_attachment_name:
-                print("Already found attachment, skipping")
+            if json_file_name == found_attachment_name:
+                print("Already found attachment, {} skipping".format(json_file_name))
                 return True
     return False
 
-"""
-Link the plan's intent to the plan URI as an attachment
-Skips the attachment if a file already exists with the same name
-"""
-def post_upload_intent(plan_data, url, email, password):
+def create_intent_file_name(plan_path):
+    return os.path.splitext(plan_path)[0] + '_intent.json'
 
-    found_intent = read_intent(plan_data)
-    if found_intent:
+def create_sample_attributes_file_name(plan_path):
+    return os.path.splitext(plan_path)[0] + '_sample_attributes.json'
+
+"""
+Generic method for JSON upload
+"""
+def post_upload_json(uri, json_data, json_file_name, url, email, password, delete=False):
+
+    found_attachment = read_attachment(uri, json_file_name)
+    if found_attachment:
         return True
-
-    plan_id = plan_data['id']
-    intent_data = plan_data['intent']
-    intent_file_name = plan_data['experiment_id'] + '_intent.json'
 
     sbh = SynBioHub(url,
                     email,
@@ -743,12 +741,14 @@ def post_upload_intent(plan_data, url, email, password):
                     'http://hub-api.sd2e.org:80/sparql',
                     {'http://sd2e.org#bead_model', 'http://sd2e.org#bead_batch'})
 
-    print("Attaching intent")
-    with open(intent_file_name, "w") as outfile:
-        json.dump(intent_data, outfile)
+    if not os.path.exists(json_file_name):
+        with open(json_file_name, "w") as outfile:
+            json.dump(json_data, outfile)
 
-    sbh.attach_file(intent_file_name, plan_id)
-    os.remove(intent_file_name)
+    sbh.attach_file(json_file_name, uri)
+
+    if delete:
+        os.remove(json_file_name)
     return True
 
 """
@@ -760,7 +760,7 @@ def post_upload_controls(plan_data):
     plan_id = plan_data['id']
     sparql = SPARQLWrapper("https://hub-api.sd2e.org/sparql")
 
-    save_bead_uri = None
+    bead_uris = []
     save_wt_uri = None
 
     # look up bead samples for plan
@@ -777,8 +777,7 @@ def post_upload_controls(plan_data):
     results = sparql.query().convert()['results']['bindings']
     for result in results:
       bead_uri = result['sample']['value']
-      if save_bead_uri == None:
-        save_bead_uri = bead_uri
+      bead_uris.append(bead_uri)
 
     # look up WT for plan
     # NCIT_C62195 is the ontology term for a wild type design
@@ -798,18 +797,19 @@ def post_upload_controls(plan_data):
       if save_wt_uri == None:
         save_wt_uri = wt_uri
 
-    if save_bead_uri != None:
-      print("Writing bead control: " + plan_id + " " + save_bead_uri)
+    bead_write_results = {}
+    bead_write_results['results'] = { 'bindings' : [] }
+    for bead_uri in bead_uris:
+      print("Writing bead control: " + plan_id + " " + bead_uri)
 
       query = """
       WITH <https://hub.sd2e.org/user/sd2e> 
       INSERT {{
       <{}> <http://sd2e.org#bead_control> <{}> .
-      }}""".format(plan_id, save_bead_uri)
+      }}""".format(plan_id, bead_uri)
       sparql.setQuery(query)
       sparql.setReturnFormat(JSON)
-      bead_write_results = sparql.query().convert()
-      print(bead_write_results)
+      bead_write_results['results']['bindings'].extend(sparql.query().convert()['results']['bindings'])
 
     if save_wt_uri != None:
       print("Writing wild type as negative control: " + plan_id + " " + save_wt_uri)
@@ -822,10 +822,7 @@ def post_upload_controls(plan_data):
       """.format(plan_id, save_wt_uri)
       sparql.setQuery(query)
       sparql.setReturnFormat(JSON)
-      wt_write_results = sparql.query().convert()
-      print(wt_write_results)
-
-      bead_write_results['results']['bindings'].extend(wt_write_results['results']['bindings'])
+      bead_write_results['results']['bindings'].extend(sparql.query().convert()['results']['bindings'])
       return bead_write_results
 
 def main(args=None):
@@ -869,8 +866,22 @@ def main(args=None):
                 docs[1].upload(args.url, args.email, args.password, SD2_EXP_COLLECTION, 2)
                 print('Plan uploaded.')
 
-            post_upload_intent(plan_data, args.url, args.email, args.password)
+            #upload intent
+            plan_base_name = os.path.basename(args.input)
+            plan_id = plan_data["id"]
+
+            post_upload_json(plan_id, plan_data["intent"], create_intent_file_name(plan_base_name), args.url, args.email, args.password)
+            
             post_upload_controls(plan_data)
+
+            # upload plan
+            post_upload_json(plan_id, plan_data, plan_base_name, args.url, args.email, args.password)
+
+            #upload sample attributes
+            sample_attribute_path = create_sample_attributes_file_name(plan_base_name)
+            with open(sample_attribute_path) as plan_sample_attributes_file:
+                plan_sample_attributes_data = json.load(plan_sample_attributes_file)
+                post_upload_json(plan_id, plan_sample_attributes_data, plan_sample_attributes_file, args.url, args.email, args.password)
 
     print('done')
 


### PR DESCRIPTION
@nroehner @bjkeller this adds plan and sample attribute uploading to xplan_to_sbol.

Happy to accept changes or feedback here. I tried to re-factor into a common function I could use to upload the plan, intent, and sample attributes (they're all JSON, afterall). 

I am finding that access to the plan and sample attributes would be useful for the YG sample downselection work I am working with Ulli and Dan.

@danbryce, @mdehavensift this should require no changes to existing xplan upload code. 

Test case includes coverage for new operations. Run below shows successful upload and re-run where no upload is done.

The sample attachments can be viewed here:

https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1

![image](https://user-images.githubusercontent.com/5033275/42484932-55cd6816-83c3-11e8-9d29-54a24931a92f.png)

```
(py3) ➜  xplan_to_sbol git:(upload_plan_sample_attributes_file) ✗ python -m unittest tests/Test_YG_Intent_Controls.py
attached file
<Response [200]>
Already found attachment, skipping
attached file
<Response [200]>
Already found attachment, skipping
attached file
<Response [200]>
Already found attachment, skipping
Writing bead control: https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1 https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s2_R298/1
Writing wild type as negative control: https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1 https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1
.
----------------------------------------------------------------------
Ran 1 test in 7.216s

OK
(py3) ➜  xplan_to_sbol git:(upload_plan_sample_attributes_file) ✗ python -m unittest tests/Test_YG_Intent_Controls.py
Already found attachment, biofab_yg_UWBF_NOR_intent_control_test_intent.json skipping
Already found attachment, biofab_yg_UWBF_NOR_intent_control_test_intent.json skipping
Already found attachment, biofab_yg_UWBF_NOR_intent_control_test.json skipping
Already found attachment, biofab_yg_UWBF_NOR_intent_control_test.json skipping
Already found attachment, biofab_yg_UWBF_NOR_intent_control_test_sample_attributes.json skipping
Already found attachment, biofab_yg_UWBF_NOR_intent_control_test_sample_attributes.json skipping
Writing bead control: https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1 https://hub.sd2e.org/user/sd2e/biofab_yeast_gates_q0_intent_control_test/s2_R298/1
Writing wild type as negative control: https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1 https://hub.sd2e.org/user/sd2e/design/UWBIOFAB_22544/1
.
----------------------------------------------------------------------
Ran 1 test in 3.133s

OK

```