### PR TITLE
Used plan attribute sample name for json upload instead of the file o…

### DIFF
--- a/xplan_to_sbol/__main__.py
+++ b/xplan_to_sbol/__main__.py
@@ -880,9 +880,10 @@ def main(args=None):
 
             #upload sample attributes
             sample_attribute_path = create_sample_attributes_file_name(plan_base_name)
+            plan_sample_attributes_data = None
             with open(sample_attribute_path) as plan_sample_attributes_file:
                 plan_sample_attributes_data = json.load(plan_sample_attributes_file)
-                post_upload_json(plan_id, plan_sample_attributes_data, plan_sample_attributes_file, args.url, args.email, args.password)
+            post_upload_json(plan_id, plan_sample_attributes_data, sample_attribute_path, args.url, args.email, args.password)
 
     print('done')
 

--- a/xplan_to_sbol/__main__.py
+++ b/xplan_to_sbol/__main__.py
@@ -883,7 +883,7 @@ def main(args=None):
             plan_sample_attributes_data = None
             with open(sample_attribute_path) as plan_sample_attributes_file:
                 plan_sample_attributes_data = json.load(plan_sample_attributes_file)
-            post_upload_json(plan_id, plan_sample_attributes_data, sample_attribute_path, args.url, args.email, args.password)
+                post_upload_json(plan_id, plan_sample_attributes_data, sample_attribute_path, args.url, args.email, args.password)
 
     print('done')
 


### PR DESCRIPTION
…bject

Pass the `sample_attribute_path`, rather than the file object, to post_upload_json. Passing the file object causes an exception.